### PR TITLE
Add fold and intersperse functions, add bracket overload where we can choose line separator

### DIFF
--- a/src/test/java/com/opencastsoftware/prettier4j/DocTest.java
+++ b/src/test/java/com/opencastsoftware/prettier4j/DocTest.java
@@ -161,12 +161,12 @@ public class DocTest {
     @Test
     void testBracket() {
         String expected = "functionCall(a, b, c)";
-        String actual = group(text("functionCall")
-                .appendLineOrEmpty(
+        String actual = text("functionCall")
+                .append(
                         Doc.intersperse(
                                 Doc.text(",").append(Doc.lineOrSpace()),
                                 Arrays.asList("a", "b", "c").stream().map(Doc::text))
-                                .bracket(2, Doc.lineOrEmpty(), Doc.text("("), Doc.text(")"))))
+                                .bracket(2, Doc.lineOrEmpty(), Doc.text("("), Doc.text(")")))
                 .render(80);
 
         assertThat(actual, is(equalTo(expected)));
@@ -175,12 +175,12 @@ public class DocTest {
     @Test
     void testBracketStringOverload() {
         String expected = "functionCall(a, b, c)";
-        String actual = group(text("functionCall")
-                .appendLineOrEmpty(
+        String actual = text("functionCall")
+                .append(
                         Doc.intersperse(
                                 Doc.text(",").append(Doc.lineOrSpace()),
                                 Arrays.asList("a", "b", "c").stream().map(Doc::text))
-                                .bracket(2, Doc.lineOrEmpty(), "(", ")")))
+                                .bracket(2, Doc.lineOrEmpty(), "(", ")"))
                 .render(80);
 
         assertThat(actual, is(equalTo(expected)));

--- a/src/test/java/com/opencastsoftware/prettier4j/Node.java
+++ b/src/test/java/com/opencastsoftware/prettier4j/Node.java
@@ -17,12 +17,9 @@ public class Node {
                         subTrees.isEmpty() ? Doc.empty()
                                 : Doc.text("[")
                                         .append(
-                                                subTrees.stream()
-                                                        .map(Node::show)
-                                                        .reduce(Doc.empty(), (left, right) -> {
-                                                            return left instanceof Doc.Empty ? right
-                                                                    : left.append(Doc.text(",")).appendLineOrSpace(right);
-                                                        }).indent(1))
+                                                Doc.intersperse(
+                                                        Doc.text(",").append(Doc.lineOrSpace()),
+                                                        subTrees.stream().map(Node::show)).indent(1))
                                         .append(Doc.text("]"))
                                         .indent(data.length())));
     }
@@ -31,12 +28,9 @@ public class Node {
         return Doc.text(data)
                 .append(
                         subTrees.isEmpty() ? Doc.empty()
-                                : subTrees.stream()
-                                        .map(Node::showPrime)
-                                        .reduce(Doc.empty(), (left, right) -> {
-                                            return left instanceof Doc.Empty ? right
-                                                    : left.append(Doc.text(",")).appendLineOrSpace(right);
-                                        })
+                                : Doc.intersperse(
+                                        Doc.text(",").append(Doc.lineOrSpace()),
+                                        subTrees.stream().map(Node::showPrime))
                                         .bracket(2, "[", "]"));
     }
 }


### PR DESCRIPTION
This makes it a lot easier to implement formatting for classic function call syntax like `f(a, b, c)`, expanding to:
```
f(
  a,
  b,
  c
)
```
There are overloads of `fold` and `intersperse` for both `Stream` and `Collection`.
We also add a `bracket` overload that allows to specify the line separator document, providing a choice of replacement document when a layout is flattened e.g.
```
f( a, b, c ) // Doc.lineOrSpace
```
and
```
f(a, b, c) // Doc.lineOrEmpty
```