### PR TITLE
Apply spotless license headers and formatting

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# Initial application of Spotless licence headers and formatting
+45bcc08d1a82c0e29db7d4a84ec7151acfffd547

--- a/src/main/java/com/opencastsoftware/prettier4j/Doc.java
+++ b/src/main/java/com/opencastsoftware/prettier4j/Doc.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2022-2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.prettier4j;
 
 import java.util.AbstractMap.SimpleEntry;

--- a/src/test/java/com/opencastsoftware/prettier4j/DocTest.java
+++ b/src/test/java/com/opencastsoftware/prettier4j/DocTest.java
@@ -1,20 +1,22 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2022-2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.prettier4j;
+
+import com.jparams.verifier.tostring.ToStringVerifier;
+import net.jqwik.api.*;
+import net.jqwik.api.constraints.IntRange;
+import nl.jqno.equalsverifier.EqualsVerifier;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
 
 import static com.opencastsoftware.prettier4j.Doc.*;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
-
-import java.util.Arrays;
-import java.util.Collections;
-
-import org.junit.jupiter.api.Test;
-
-import com.jparams.verifier.tostring.ToStringVerifier;
-
-import net.jqwik.api.*;
-import net.jqwik.api.constraints.IntRange;
-import nl.jqno.equalsverifier.EqualsVerifier;
 
 public class DocTest {
     /** The example tree data structure from the original paper */

--- a/src/test/java/com/opencastsoftware/prettier4j/Node.java
+++ b/src/test/java/com/opencastsoftware/prettier4j/Node.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  Copyright 2022-2023 Opencast Software Europe Ltd
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.prettier4j;
 
 import java.util.List;


### PR DESCRIPTION
Applies [spotless](https://github.com/diffplug/spotless) license header and formatting steps.