### PR TITLE
Add a Margin doc to enable prefixing lines with a margin

### DIFF
--- a/src/main/java/com/opencastsoftware/prettier4j/Doc.java
+++ b/src/main/java/com/opencastsoftware/prettier4j/Doc.java
@@ -1516,7 +1516,7 @@ public abstract class Doc {
         return alternatives(doc.flatten(), doc);
     }
 
-    private static class Entry {
+    static final class Entry {
         private final int indent;
         private final Doc margin;
         private final Doc doc;
@@ -1562,7 +1562,7 @@ public abstract class Doc {
         }
     }
 
-    private static Entry entry(int indent, Doc margin, Doc doc) {
+    static Entry entry(int indent, Doc margin, Doc doc) {
         return new Entry(indent, margin, doc);
     }
 

--- a/src/main/java/com/opencastsoftware/prettier4j/ansi/Attrs.java
+++ b/src/main/java/com/opencastsoftware/prettier4j/ansi/Attrs.java
@@ -59,7 +59,7 @@ public class Attrs {
     }
 
     public static String transition(long prev, long next) {
-        if (next == NULL) {
+        if (next <= EMPTY) {
             return isEmpty(prev) ? "" : AnsiConstants.RESET;
         }
 

--- a/src/test/java/com/opencastsoftware/prettier4j/DocTest.java
+++ b/src/test/java/com/opencastsoftware/prettier4j/DocTest.java
@@ -1449,6 +1449,16 @@ public class DocTest {
     }
 
     @Test
+    void testEntryEquals() {
+        EqualsVerifier.forClass(Entry.class).usingGetClass().verify();
+    }
+
+    @Test
+    void testEntryToString() {
+        ToStringVerifier.forClass(Entry.class).verify();
+    }
+
+    @Test
     void testEquals() {
         Doc left = docsWithParams().sample();
 

--- a/src/test/java/com/opencastsoftware/prettier4j/DocTest.java
+++ b/src/test/java/com/opencastsoftware/prettier4j/DocTest.java
@@ -213,6 +213,13 @@ public class DocTest {
     }
 
     @Test
+    void testMarginWithLineSeparator() {
+        assertThrows(IllegalArgumentException.class, () -> {
+            text("bla").margin(lineOrSpace());
+        });
+    }
+
+    @Test
     void testMargin() {
         String expected = "\n|functionCall(\n|  a,\n|  b,\n|  c\n|)";
 

--- a/src/test/java/com/opencastsoftware/prettier4j/DocTest.java
+++ b/src/test/java/com/opencastsoftware/prettier4j/DocTest.java
@@ -1456,7 +1456,7 @@ public class DocTest {
         EqualsVerifier
                 .forClasses(
                         Text.class, Append.class, Param.class,
-                        Alternatives.class, Indent.class,
+                        Alternatives.class, Indent.class, Margin.class,
                         LineOr.class, Escape.class, Styled.class)
                 .usingGetClass()
                 .withPrefabValues(Doc.class, left, right)
@@ -1467,7 +1467,7 @@ public class DocTest {
     void testToString() {
         ToStringVerifier
                 .forClasses(
-                        Text.class, Append.class,
+                        Text.class, Append.class, Margin.class,
                         Alternatives.class, Indent.class,
                         LineOr.class, Empty.class, Escape.class,
                         Reset.class, Styled.class, Param.class)


### PR DESCRIPTION
This enables usages like prefixing documents with a line gutter or highlight, with support for ANSI styled text in the margin document.