### PR TITLE
Interleave rendering with layout to reduce memory usage

### DIFF
--- a/src/main/java/com/opencastsoftware/prettier4j/Doc.java
+++ b/src/main/java/com/opencastsoftware/prettier4j/Doc.java
@@ -1855,9 +1855,7 @@ public abstract class Doc {
             // Note reverse order
             if (entryIndent > 0) {
                 // Send out the indent spaces
-                char[] indentChars = new char[entryIndent];
-                Arrays.fill(indentChars, ' ');
-                String indentSpaces = new String(indentChars);
+                String indentSpaces = Indents.get(entryIndent);
                 inQueue.addFirst(entry(entryIndent, entryMargin, text(indentSpaces)));
             }
             // Send out the current margin

--- a/src/main/java/com/opencastsoftware/prettier4j/Doc.java
+++ b/src/main/java/com/opencastsoftware/prettier4j/Doc.java
@@ -1637,7 +1637,7 @@ public abstract class Doc {
         }
     }
 
-    static Entry entry(int indent, Doc margin, Doc doc) {
+    private static Entry entry(int indent, Doc margin, Doc doc) {
         return new Entry(indent, margin, doc);
     }
 
@@ -1652,7 +1652,7 @@ public abstract class Doc {
      * @return true if we can fit all {@link Doc.Text entries} up to the
      * next line break into the remaining characters of the current line.
      */
-    static boolean fits(int remaining, Deque<Entry> entries) {
+    static boolean fits(int remaining, Queue<Entry> entries) {
         if (remaining < 0)
             return false;
 
@@ -1686,15 +1686,15 @@ public abstract class Doc {
      * @param position the position in the current line.
      * @return the entries of the chosen layout.
      */
-    static Deque<Entry> chooseLayout(Doc left, Doc right, RenderOptions options, Doc margin, int indent, int position) {
-        Deque<Entry> leftEntries = normalize(left, options, margin, indent, position);
+    private static Queue<Entry> chooseLayout(Doc left, Doc right, RenderOptions options, Doc margin, int indent, int position) {
+        Queue<Entry> leftEntries = layout(left, options, margin, indent, position);
 
         int remaining = options.lineWidth() - position;
 
         if (fits(remaining, leftEntries)) {
             return leftEntries;
         } else {
-            return normalize(right, options, margin, indent, position);
+            return layout(right, options, margin, indent, position);
         }
     }
 
@@ -1710,173 +1710,173 @@ public abstract class Doc {
      * @param position the current position in the line.
      * @return a queue of entries to be rendered.
      */
-    static Deque<Entry> normalize(Doc doc, RenderOptions options, Doc margin, int indent, int position) {
+    private static Queue<Entry> layout(Doc doc, RenderOptions options, Doc margin, int indent, int position) {
         // Not yet normalized entries
         Deque<Entry> inQueue = new ArrayDeque<>();
 
         // Normalized entries
-        Deque<Entry> outQueue = new ArrayDeque<>();
+        Queue<Entry> outQueue = new ArrayDeque<>();
 
         // Start with the outer Doc
         inQueue.add(entry(indent, margin, doc));
 
         while (!inQueue.isEmpty()) {
             Entry topEntry = inQueue.removeFirst();
-
-            int entryIndent = topEntry.indent();
-            Doc entryMargin = topEntry.margin();
-            Doc entryDoc = topEntry.doc();
-
-            if (entryDoc instanceof Append) {
-                // Eliminate Append
-                Append appendDoc = (Append) entryDoc;
-                // Note reverse order
-                inQueue.addFirst(entry(entryIndent, entryMargin, appendDoc.right()));
-                inQueue.addFirst(entry(entryIndent, entryMargin, appendDoc.left()));
-            } else if (entryDoc instanceof Styled) {
-                // Eliminate Styled
-                Styled styledDoc = (Styled) entryDoc;
-                if (options.emitAnsiEscapes()) {
-                    // Note reverse order
-                    inQueue.addFirst(entry(entryIndent, entryMargin, Reset.getInstance()));
-                    inQueue.addFirst(entry(entryIndent, entryMargin, styledDoc.doc()));
-                    inQueue.addFirst(entry(entryIndent, entryMargin, new Escape(styledDoc.styles())));
-                } else {
-                    // Ignore styles and emit the underlying Doc
-                    inQueue.addFirst(entry(entryIndent, entryMargin, styledDoc.doc()));
-                }
-            } else if (entryDoc instanceof Indent) {
-                // Eliminate Indent
-                Indent indentDoc = (Indent) entryDoc;
-                int newIndent = entryIndent + indentDoc.indent();
-                inQueue.addFirst(entry(newIndent, entryMargin, indentDoc.doc()));
-            } else if (entryDoc instanceof Margin) {
-                // Eliminate Margin
-                Margin marginDoc = (Margin) entryDoc;
-                // Note reverse order
-                Doc newMargin = entryMargin.append(marginDoc.margin());
-                inQueue.addFirst(entry(entryIndent, newMargin, marginDoc.doc()));
-            } else if (entryDoc instanceof Alternatives) {
-                // Eliminate Alternatives
-                Alternatives altDoc = (Alternatives) entryDoc;
-                // These entries are already normalized
-                Deque<Entry> chosenEntries = chooseLayout(
-                        altDoc.left(), altDoc.right(),
-                        options, entryMargin, entryIndent, position);
-                chosenEntries.forEach(outQueue::addLast);
-            } else if (entryDoc instanceof WrapText) {
-                WrapText wrapDoc = (WrapText) entryDoc;
-                String wrapText = wrapDoc.text();
-                int textLength = wrapText.length();
-                if (textLength == 0) { continue; }
-
-                StringBuilder wrapped = new StringBuilder(options.lineWidth());
-
-                int textOffset = 0;
-                int wordStart = -1;
-                for (; textOffset < textLength; textOffset++) {
-                    char currentChar = wrapText.charAt(textOffset);
-
-                    boolean isInWord = wordStart >= 0;
-                    boolean isWhitespace = Character.isWhitespace(currentChar);
-                    boolean isStartOfWord = !isWhitespace && !isInWord;
-
-                    if (isStartOfWord) {
-                        wordStart = textOffset;
-                        isInWord = true;
-                    }
-
-                    boolean isLastChar = textOffset == textLength - 1;
-                    boolean isEndOfWord = (isWhitespace || isLastChar) && isInWord;
-                    boolean isFirstWord = wrapped.length() == 0;
-
-                    if (isEndOfWord) {
-                        int precedingSpaces = isFirstWord ? 0 : 1;
-                        int wordEnd = isLastChar ? textLength : textOffset;
-                        int wordLength = wordEnd - wordStart + precedingSpaces;
-                        int remaining = options.lineWidth() - position;
-                        if (remaining < wordLength) {
-                            if (isFirstWord) {
-                                // It's a really long word, so send it out to make progress
-                                wrapped.append(wrapText, wordStart, wordEnd);
-                                position += wordLength;
-                                wordStart = -1;
-                            }
-                            if (!isLastChar) break;
-                        } else {
-                            if (!isFirstWord) { wrapped.append(' '); }
-                            wrapped.append(wrapText, wordStart, wordEnd);
-                            position += wordLength;
-                            wordStart = -1;
-                        }
-                    }
-                }
-
-                // Skip trailing whitespace
-                while (textOffset < textLength && Character.isWhitespace(wrapText.charAt(textOffset))) {
-                    textOffset++;
-                }
-
-                int restOffset = wordStart > 0 ? wordStart : textOffset;
-                int remainingChars = textLength - restOffset;
-                if (remainingChars > 0) {
-                    // Send out remainder prefixed by line separator
-                    String remainingText = wrapText.substring(restOffset);
-                    inQueue.addFirst(entry(entryIndent, entryMargin, wrapText(remainingText)));
-                    inQueue.addFirst(entry(entryIndent, entryMargin, line()));
-                }
-
-                // Send out the wrapped line
-                inQueue.addFirst(entry(entryIndent, entryMargin, text(wrapped.toString())));
-
-            } else if (entryDoc instanceof Text) {
-                Text textDoc = (Text) entryDoc;
-                // Keep track of line length
-                position += textDoc.text().length();
-                outQueue.addLast(topEntry);
-            } else if (entryDoc instanceof LineOr) {
-                // Reset line length
-                position = entryIndent;
-                // Note reverse order
-                if (entryIndent > 0) {
-                    // Send out the indent spaces
-                    char[] indentChars = new char[entryIndent];
-                    Arrays.fill(indentChars, ' ');
-                    String indentSpaces = new String(indentChars);
-                    inQueue.addFirst(entry(entryIndent, entryMargin, text(indentSpaces)));
-                }
-                // Send out the current margin
-                inQueue.addFirst(entry(entryIndent, entryMargin, entryMargin));
-                outQueue.addLast(topEntry);
-            } else if (entryDoc instanceof Escape) {
-                outQueue.addLast(topEntry);
-            } else if (entryDoc instanceof Reset) {
-                outQueue.addLast(topEntry);
-            }
-            // Eliminate Empty
+            position = layoutEntry(options, inQueue, outQueue, topEntry, position);
         }
 
         return outQueue;
     }
 
-    /**
-     * Renders the input {@link Doc} into an {@link Appendable}, attempting to lay out the document
-     * according to the rendering {@code options}.
-     *
-     * @param doc     the document to be rendered.
-     * @param options the options to use for rendering.
-     * @param output  the output to render into.
-     * @throws IOException if the {@link Appendable} {@code output} throws when {@link Appendable#append(CharSequence) append}ed.
-     */
-    public static void render(Doc doc, RenderOptions options, Appendable output) throws IOException {
-        if (doc.hasParams()) { throw new IllegalStateException("This Doc contains unbound parameters"); }
+    private static int wrapText(RenderOptions options, Deque<Entry> inQueue, Entry entry, WrapText wrapDoc, int position) {
+        int entryIndent = entry.indent();
+        Doc entryMargin = entry.margin();
 
-        Deque<Entry> renderQueue = normalize(doc, options, empty(), 0, 0);
-        AttrsStack attrsStack = new AttrsStack();
+        String wrapText = wrapDoc.text();
+        int textLength = wrapText.length();
+        if (textLength == 0) { return position; }
 
-        for (Entry entry : renderQueue) {
+        StringBuilder wrapped = new StringBuilder(options.lineWidth());
+
+        int textOffset = 0;
+        int wordStart = -1;
+        for (; textOffset < textLength; textOffset++) {
+            char currentChar = wrapText.charAt(textOffset);
+
+            boolean isInWord = wordStart >= 0;
+            boolean isWhitespace = Character.isWhitespace(currentChar);
+            boolean isStartOfWord = !isWhitespace && !isInWord;
+
+            if (isStartOfWord) {
+                wordStart = textOffset;
+                isInWord = true;
+            }
+
+            boolean isLastChar = textOffset == textLength - 1;
+            boolean isEndOfWord = (isWhitespace || isLastChar) && isInWord;
+            boolean isFirstWord = wrapped.length() == 0;
+
+            if (isEndOfWord) {
+                int precedingSpaces = isFirstWord ? 0 : 1;
+                int wordEnd = isLastChar ? textLength : textOffset;
+                int wordLength = wordEnd - wordStart + precedingSpaces;
+                int remaining = options.lineWidth() - position;
+                if (remaining < wordLength) {
+                    if (isFirstWord) {
+                        // It's a really long word, so send it out to make progress
+                        wrapped.append(wrapText, wordStart, wordEnd);
+                        position += wordLength;
+                        wordStart = -1;
+                    }
+                    if (!isLastChar) break;
+                } else {
+                    if (!isFirstWord) { wrapped.append(' '); }
+                    wrapped.append(wrapText, wordStart, wordEnd);
+                    position += wordLength;
+                    wordStart = -1;
+                }
+            }
+        }
+
+        // Skip trailing whitespace
+        while (textOffset < textLength && Character.isWhitespace(wrapText.charAt(textOffset))) {
+            textOffset++;
+        }
+
+        int restOffset = wordStart > 0 ? wordStart : textOffset;
+        int remainingChars = textLength - restOffset;
+        if (remainingChars > 0) {
+            // Send out remainder prefixed by line separator
+            String remainingText = wrapText.substring(restOffset);
+            inQueue.addFirst(entry(entryIndent, entryMargin, wrapText(remainingText)));
+            inQueue.addFirst(entry(entryIndent, entryMargin, line()));
+        }
+
+        // Send out the wrapped line
+        inQueue.addFirst(entry(entryIndent, entryMargin, text(wrapped.toString())));
+
+        return position;
+    }
+
+    private static int layoutEntry(RenderOptions options, Deque<Entry> inQueue, Queue<Entry> outQueue, Entry topEntry, int position) {
+        int entryIndent = topEntry.indent();
+        Doc entryMargin = topEntry.margin();
+        Doc entryDoc = topEntry.doc();
+
+        if (entryDoc instanceof Append) {
+            // Eliminate Append
+            Append appendDoc = (Append) entryDoc;
+            // Note reverse order
+            inQueue.addFirst(entry(entryIndent, entryMargin, appendDoc.right()));
+            inQueue.addFirst(entry(entryIndent, entryMargin, appendDoc.left()));
+        } else if (entryDoc instanceof Styled) {
+            // Eliminate Styled
+            Styled styledDoc = (Styled) entryDoc;
+            if (options.emitAnsiEscapes()) {
+                // Note reverse order
+                inQueue.addFirst(entry(entryIndent, entryMargin, Reset.getInstance()));
+                inQueue.addFirst(entry(entryIndent, entryMargin, styledDoc.doc()));
+                inQueue.addFirst(entry(entryIndent, entryMargin, new Escape(styledDoc.styles())));
+            } else {
+                // Ignore styles and emit the underlying Doc
+                inQueue.addFirst(entry(entryIndent, entryMargin, styledDoc.doc()));
+            }
+        } else if (entryDoc instanceof Indent) {
+            // Eliminate Indent
+            Indent indentDoc = (Indent) entryDoc;
+            int newIndent = entryIndent + indentDoc.indent();
+            inQueue.addFirst(entry(newIndent, entryMargin, indentDoc.doc()));
+        } else if (entryDoc instanceof Margin) {
+            // Eliminate Margin
+            Margin marginDoc = (Margin) entryDoc;
+            // Note reverse order
+            Doc newMargin = entryMargin.append(marginDoc.margin());
+            inQueue.addFirst(entry(entryIndent, newMargin, marginDoc.doc()));
+        } else if (entryDoc instanceof Alternatives) {
+            // Eliminate Alternatives
+            Alternatives altDoc = (Alternatives) entryDoc;
+            // These entries are already normalized
+            Queue<Entry> chosenEntries = chooseLayout(
+                    altDoc.left(), altDoc.right(),
+                    options, entryMargin, entryIndent, position);
+            outQueue.addAll(chosenEntries);
+        } else if (entryDoc instanceof WrapText) {
+            // Eliminate WrapText
+            WrapText wrapDoc = (WrapText) entryDoc;
+            position = wrapText(options, inQueue, topEntry, wrapDoc, position);
+        } else if (entryDoc instanceof Text) {
+            Text textDoc = (Text) entryDoc;
+            // Keep track of line length
+            position += textDoc.text().length();
+            outQueue.add(topEntry);
+        } else if (entryDoc instanceof LineOr) {
+            // Reset line length
+            position = entryIndent;
+            // Note reverse order
+            if (entryIndent > 0) {
+                // Send out the indent spaces
+                char[] indentChars = new char[entryIndent];
+                Arrays.fill(indentChars, ' ');
+                String indentSpaces = new String(indentChars);
+                inQueue.addFirst(entry(entryIndent, entryMargin, text(indentSpaces)));
+            }
+            // Send out the current margin
+            inQueue.addFirst(entry(entryIndent, entryMargin, entryMargin));
+            outQueue.add(topEntry);
+        } else if (entryDoc instanceof Escape) {
+            outQueue.add(topEntry);
+        } else if (entryDoc instanceof Reset) {
+            outQueue.add(topEntry);
+        }
+        // Eliminate Empty
+
+        return position;
+    }
+
+    private static void flushToOutput(Deque<Entry> outQueue, AttrsStack attrsStack, Appendable output) throws IOException {
+        while (!outQueue.isEmpty()) {
+            Entry entry = outQueue.removeFirst();
             Doc entryDoc = entry.doc();
-
             // normalization reduces Doc to Text, LineOr, Escape and Reset
             if (entryDoc instanceof Text) {
                 Text textDoc = (Text) entryDoc;
@@ -1895,6 +1895,32 @@ public abstract class Doc {
                 attrsStack.pushLast(newAttrs);
                 output.append(Attrs.transition(prevAttrs, newAttrs));
             }
+        }
+    }
+
+    /**
+     * Renders the input {@link Doc} into an {@link Appendable}, attempting to lay out the document
+     * according to the rendering {@code options}.
+     *
+     * @param doc     the document to be rendered.
+     * @param options the options to use for rendering.
+     * @param output  the output to render into.
+     * @throws IOException if the {@link Appendable} {@code output} throws when {@link Appendable#append(CharSequence) append}ed.
+     */
+    public static void render(Doc doc, RenderOptions options, Appendable output) throws IOException {
+        if (doc.hasParams()) { throw new IllegalStateException("This Doc contains unbound parameters"); }
+
+        int position = 0;
+        Deque<Entry> inQueue = new ArrayDeque<>();
+        Deque<Entry> outQueue = new ArrayDeque<>();
+        AttrsStack attrsStack = new AttrsStack();
+
+        inQueue.add(entry(0, empty(), doc));
+
+        while (!inQueue.isEmpty()) {
+            Entry topEntry = inQueue.removeFirst();
+            position = layoutEntry(options, inQueue, outQueue, topEntry, position);
+            flushToOutput(outQueue, attrsStack, output);
         }
     }
 

--- a/src/main/java/com/opencastsoftware/prettier4j/Indents.java
+++ b/src/main/java/com/opencastsoftware/prettier4j/Indents.java
@@ -1,0 +1,37 @@
+package com.opencastsoftware.prettier4j;
+
+import java.util.*;
+
+/**
+ * Holds a cache of indent {@link String}s.
+ * <p>
+ * Most source code is indented by 20 or fewer spaces, so we cache
+ * indent {@link String}s of up to 20 spaces to avoid allocating them
+ * repeatedly during rendering.
+ */
+final class Indents {
+    private static final int CACHED_INDENTS = 20;
+    private static final String[] indents = new String[CACHED_INDENTS];
+
+    static {
+        for (int i = 1; i <= CACHED_INDENTS; i++) {
+            indents[i - 1] = makeIndent(i).intern();
+        }
+    }
+
+    private static String makeIndent(int i) {
+        char[] indentChars = new char[i];
+        Arrays.fill(indentChars, ' ');
+        return new String(indentChars);
+    }
+
+    public static String get(int i) {
+        if (i > CACHED_INDENTS) {
+            return makeIndent(i);
+        } else {
+            return indents[i - 1];
+        }
+    }
+
+    private Indents() {}
+}

--- a/src/main/java/com/opencastsoftware/prettier4j/Indents.java
+++ b/src/main/java/com/opencastsoftware/prettier4j/Indents.java
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText:  © 2024 Opencast Software Europe Ltd <https://opencastsoftware.com>
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package com.opencastsoftware.prettier4j;
 
 import java.util.*;

--- a/src/test/java/com/opencastsoftware/prettier4j/DocTest.java
+++ b/src/test/java/com/opencastsoftware/prettier4j/DocTest.java
@@ -1462,7 +1462,7 @@ public class DocTest {
             @ForAll @IntRange(min = 10, max = 200) int width,
             @ForAll("wrappableText") String textToWrap
     ) {
-        String textWrapWithPrettier = new WrapText(textToWrap).render(width);
+        String textWrapWithPrettier = wrapText(textToWrap).render(width);
         String textWrapWithApache = WordUtils.wrap(textToWrap, width, null, false, "\\s+");
         assertThat(textWrapWithPrettier, is(equalTo(textWrapWithApache.strip().replaceAll("[\t\r\f\u000b]", " "))));
     }
@@ -1600,7 +1600,7 @@ public class DocTest {
                 () -> Arbitraries.strings().ofMaxLength(10).map(Doc::text),
                 () -> Arbitraries.strings().ofMaxLength(10).map(Doc::text),
                 // WrapText
-                () -> wrappableText().map(WrapText::new),
+                () -> wrappableText().map(Doc::wrapText),
                 // Empty
                 // Repeated to reduce the frequency of recursive generation
                 () -> Arbitraries.just(Doc.empty()),
@@ -1642,7 +1642,7 @@ public class DocTest {
                () -> Arbitraries.strings().ofMaxLength(10).map(Doc::text),
                () -> Arbitraries.strings().ofMaxLength(10).map(Doc::text),
                // WrapText
-               () -> wrappableText().map(WrapText::new),
+               () -> wrappableText().map(Doc::wrapText),
                // Empty
                // Repeated to reduce the frequency of recursive generation
                () -> Arbitraries.just(Doc.empty()),
@@ -1682,7 +1682,7 @@ public class DocTest {
                 () -> Arbitraries.strings().ofMaxLength(10).map(Doc::text),
                 () -> Arbitraries.strings().ofMaxLength(10).map(Doc::text),
                 // WrapText
-                () -> wrappableText().map(WrapText::new),
+                () -> wrappableText().map(Doc::wrapText),
                 // Empty
                 // Repeated to reduce the frequency of recursive generation
                 () -> Arbitraries.just(Doc.empty()),


### PR DESCRIPTION
This PR refactors rendering to interleave producing layouts for rendering with rendering those layouts to the output.

The change is very simple - rather than producing all entries for rendering and then rendering them all in one go, after each iteration of layout we flush all entries in the render queue.

This change does nothing to reduce allocations overall, but it means that we don't need to hold on to lots of entries in the render queue unnecessarily.