### PR TITLE
Add a Doc.Link to enable hyperlinks to be produced on supported terminals

### DIFF
--- a/src/main/java/com/opencastsoftware/prettier4j/ansi/AnsiConstants.java
+++ b/src/main/java/com/opencastsoftware/prettier4j/ansi/AnsiConstants.java
@@ -6,6 +6,8 @@ package com.opencastsoftware.prettier4j.ansi;
 
 import org.apiguardian.api.API;
 
+import java.net.URI;
+
 import static org.apiguardian.api.API.Status.INTERNAL;
 
 /**
@@ -21,6 +23,24 @@ public class AnsiConstants {
      * The Reset SGR (Select Graphic Rendition) sequence.
      */
     public static final String RESET = "\u001b[0m";
+    /**
+     * The OSC (Operating System Command) escape sequence.
+     */
+    public static final String OSC = "\u001b]";
+    /**
+     * The ST (String Terminator) escape sequence.
+     */
+    public static final String ST = "\u001b\\";
+    /**
+     * The escape sequence for opening a hyperlink.
+     * <p>
+     * This sequence must be followed by the {@link URI} of the hyperlink, then the {@link AnsiConstants#ST} sequence.
+     */
+    public static final String OPEN_LINK = OSC + 8 + ";;";
+    /**
+     * The escape sequence for closing a hyperlink.
+     */
+    public static final String CLOSE_LINK = OSC + 8 + ";;" + ST;
 
     private AnsiConstants() {}
 }

--- a/src/main/java/com/opencastsoftware/prettier4j/ansi/Styles.java
+++ b/src/main/java/com/opencastsoftware/prettier4j/ansi/Styles.java
@@ -113,7 +113,24 @@ public class Styles {
     /**
      * An operator that is used to apply display styles to a {@link com.opencastsoftware.prettier4j.Doc Doc}.
      */
-    public interface StylesOperator extends LongUnaryOperator {}
+    @FunctionalInterface
+    public interface StylesOperator extends LongUnaryOperator {
+        StylesOperator IDENTITY = attrs -> attrs;
+
+        @Override
+        default StylesOperator compose(LongUnaryOperator before) {
+            return attrs -> applyAsLong(before.applyAsLong(attrs));
+        }
+
+        @Override
+        default StylesOperator andThen(LongUnaryOperator after) {
+            return attrs -> after.applyAsLong(applyAsLong(attrs));
+        }
+
+        static StylesOperator identity() {
+            return IDENTITY;
+        }
+    }
 
     static abstract class ColorStylesOperator implements StylesOperator {
         protected final Color color;


### PR DESCRIPTION
This PR enables `Doc`s to link to a URI using terminal hyperlinks in supported terminals.

See <a href="https://web.archive.org/web/20240525100920/https://gist.github.com/egmontkob/eb114294efbcd5adb1944c9f3cb5feda">Hyperlinks (a.k.a. HTML-like anchors) in terminal emulators</a> for more details.

Note that nested hyperlinks are not supported in this implementation.

I can't think of a legitimate reason to support them either - it would be very unclear for users and easy to abuse by linking to an unexpected URI in the middle of another.